### PR TITLE
Add support for using XeroClient without XeroBundle, and add unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ web/bundles/*
 app/config/parameters.ini
 app/config/parameters.yml
 composer.lock
+coverage/*

--- a/Tests/DependencyInjection/BlackOpticXeroExtensionTest.php
+++ b/Tests/DependencyInjection/BlackOpticXeroExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BlackOptic\Bundle\XeroBundle\Tests\DependencyInjection;
+
+use BlackOptic\Bundle\XeroBundle\Tests\TestBase;
+use BlackOptic\Bundle\XeroBundle\DependencyInjection\BlackOpticXeroExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class BlackOpticXeroExtensionTest extends TestBase
+{
+    protected $options;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->options = array(
+          'black_optic_xero' => array(
+            'consumer_key' => '',
+            'consumer_secret' => '',
+            'private_key' => '',
+          ),
+        );
+
+        $this->container = new ContainerBuilder();
+    }
+
+    public function testBadConfig()
+    {
+        $this->setExpectedException('\BlackOptic\Bundle\XeroBundle\Exception\FileNotFoundException');
+        $bundle = new BlackOpticXeroExtension();
+
+        $bundle->load($this->options, $this->container);
+    }
+
+    public function testConfig()
+    {
+        $this->options['black_optic_xero']['private_key'] = $this->pemFile;
+
+        $bundle = new BlackOpticXeroExtension();
+
+        $bundle->load($this->options, $this->container);
+    }
+}

--- a/Tests/TestBase.php
+++ b/Tests/TestBase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace BlackOptic\Bundle\XeroBundle\Tests;
+
+abstract class TestBase extends \PHPUnit_Framework_TestCase
+{
+
+    protected $pemFile;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->pemFile = $this->createPrivateKey();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        if (file_exists($this->pemFile))
+        {
+            unlink($this->pemFile);
+        }
+    }
+
+    protected function createPrivateKey()
+    {
+        $pemFile =  md5(microtime()) . '.pem';
+        $resource = openssl_pkey_new(['digest_alg' => 'sha1', 'private_key_bits' => 1024, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($resource, $output);
+
+        file_put_contents($pemFile, $output);
+
+        return $pemFile;
+   }
+}

--- a/Tests/XeroClientTest.php
+++ b/Tests/XeroClientTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BlackOptic\Bundle\XeroBundle\Tests;
+
+use BlackOptic\Bundle\XeroBundle\XeroClient;
+
+class XeroClientTest extends TestBase
+{
+    protected $options;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->options = array(
+            'base_url' => 'https://api.xero.com/api.xro/2.0',
+            'consumer_key' => '',
+            'consumer_secret' => '',
+            'private_key' => '',
+        );
+    }
+
+    public function testInstantiationWithoutKey()
+    {
+        $this->setExpectedException('\BlackOptic\Bundle\XeroBundle\Exception\FileNotFoundException');
+        $client = new XeroClient($this->options);
+    }
+
+    public function testInstantiationWithKey()
+    {
+        $this->options['private_key'] = $this->pemFile;
+
+        $client = new XeroClient($this->options);
+
+        $this->assertNotNull($client);
+
+        // Test set token methods.
+        $client->setToken('a', 'b');
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+$loader = require 'vendor/autoload.php';
+$loader->add('BlackOptic\\Bundle\\XeroBundle\\Tests', __DIR__);

--- a/XeroClient.php
+++ b/XeroClient.php
@@ -6,6 +6,7 @@ use Guzzle\Common\Collection;
 use Guzzle\Plugin\Oauth\OauthPlugin;
 use Guzzle\Service\Client;
 use Guzzle\Service\Description\ServiceDescription;
+use BlackOptic\Bundle\XeroBundle\Exception\FileNotFoundException;
 
 class XeroClient extends Client
 {
@@ -39,6 +40,10 @@ class XeroClient extends Client
             $config['token_secret'] = & $this->tokenSecret;
         }
 
+        if (empty($config['private_key']) || !file_exists($config['private_key'])) {
+            throw new FileNotFoundException('Unable able to find file: ' . $config['private_key']);
+        }
+
         $privateKey = file_get_contents($config['private_key']);
 
         $config['signature_method'] = 'RSA-SHA1';
@@ -49,6 +54,10 @@ class XeroClient extends Client
             openssl_free_key($privateKeyId);
             return $signature;
         };
+
+        if ($config['signature_callback'] === '') {
+            throw new \Exception('Could not create signature from key');
+        }
 
         $config = Collection::fromConfig($config, array(), $required);
         parent::__construct($config->get('base_url'), $config);

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "symfony/symfony": "2.*",
         "guzzle/guzzle": "3.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "BlackOptic\\Bundle\\XeroBundle": ""

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="Tests/bootstrap.php">
+  <testsuites>
+    <testsuite name="XeroBundle Test Suite">
+      <directory>Tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory>.</directory>
+      <exclude>
+        <directory>Tests</directory>
+        <directory>vendor</directory>
+        <directory>coverage</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
This Pull Request will allow someone to use XeroClient without having to use Symfony2 Bundles. Also I added unit tests for this project with near 100% coverage.

Do you still have interest in maintaining this repository or should I permanently fork out XeroClient out of XeroBundle?
